### PR TITLE
Add TriggerPort API for digital triggers

### DIFF
--- a/ExpAssets/Config/TraceLab_params.py
+++ b/ExpAssets/Config/TraceLab_params.py
@@ -19,11 +19,13 @@ auto_generate = False  # whether to generate figures without prompting in captur
 auto_generate_count = 10  # number of figures to generate in auto-generate/capture mode
 
 #########################################
-# Available Hardware
+# Digital Trigger Configuration
 #########################################
-eye_tracking = False
-eye_tracker_available = False
-labjack_available = False
+requires_triggers = False
+labjack_port = 'FIO' # Either FIO, EIO, or CIO
+trigger_codes = {
+
+}
 
 #########################################
 # Environment Aesthetic Defaults
@@ -121,11 +123,6 @@ min_linear_acuteness = 0.1  # must be between 0 and 1; low vals advised, higher 
 slope_magnitude = (0.25, 0.5)  # 0 = a straight line (ie. no curve), 1 = an infinitely steep curve (hint: don't pick this ;)
 peak_shift = (0.25, 0.5)  # 0 == perfect symmetry (ie. bell curve) and 1 == a right  triangle
 curve_sheer = (0.1, 0.3)  # this is hard to describe, but 1 is again an impossible value, and this will grow to lunacy fast
-
-########################################
-# Labjack Codes
-########################################
-trigger_codes = {}
 
 ########################################
 # tlf Controls

--- a/ExpAssets/Resources/code/communication.py
+++ b/ExpAssets/Resources/code/communication.py
@@ -102,7 +102,7 @@ class TriggerPort(object):
         time.sleep(duration / 1000.0)
         self._write_trigger(0)
 
-    def _write_trigger(self, value, duration):
+    def _write_trigger(self, value):
         # Device-specific trigger code implementation. This actually sends a
         # given code to the hardware.
         pass
@@ -120,9 +120,9 @@ class U3Port(TriggerPort):
         self._write_reg = LABJACK_REGISTERS[P.labjack_port]
         # TODO: Ensure requested port configured as digital out
 
-    def _write_trigger(self, value, duration):
+    def _write_trigger(self, value):
         # Fast method from Appelhoff & Stenner (2021), may be erratic on Windows
-        self._device.writeRegister(self.write_reg, 0xFF + value)
+        self._device.writeRegister(self._write_reg, 0xFF + value)
 
 
 

--- a/ExpAssets/Resources/code/communication.py
+++ b/ExpAssets/Resources/code/communication.py
@@ -24,21 +24,26 @@ def get_trigger_port():
     if package_available('u3'):
         import u3
         if u3.deviceCount(devType=3) > 0:
-            return U3Port()
+            dev = u3.U3()
+            return U3Port(dev)
 
     # If no physical trigger port available, return a virtual one
-    return VirtualPort()
+    return VirtualPort(device=None)
 
 
 
 class TriggerPort(object):
     """A class for sending digital trigger codes to external hardware.
 
+    Args:
+        device: The object representing the hardware device to use for sending
+            digital triggers (e.g. ``u3.U3``). Can be None.
+
     """
-    def __init__(self):
+    def __init__(self, device):
         # NOTE: Codes may be implementation-specific to allow for preprocessing
         self.codes = {}
-        self._device = None
+        self._device = device
         self._hardware_init()
 
     def _hardware_init(self):
@@ -114,8 +119,6 @@ class U3Port(TriggerPort):
 
     """
     def _hardware_init(self):
-        import u3
-        self._device = u3.U3()
         self._device.getCalibrationData()
         self._write_reg = LABJACK_REGISTERS[P.labjack_port]
         # TODO: Ensure requested port configured as digital out

--- a/ExpAssets/Resources/code/communication.py
+++ b/ExpAssets/Resources/code/communication.py
@@ -124,7 +124,7 @@ class U3Port(TriggerPort):
 
     def _write_trigger(self, value):
         # Fast method from Appelhoff & Stenner (2021), may be erratic on Windows
-        self._device.writeRegister(self._write_reg, 0xFF + value)
+        self._device.writeRegister(self._write_reg, 0xFF00 + (value & 0xFF))
 
 
 

--- a/ExpAssets/Resources/code/communication.py
+++ b/ExpAssets/Resources/code/communication.py
@@ -1,0 +1,133 @@
+import time
+
+from klibs import P
+from klibs.KLInternal import package_available
+
+
+
+LABJACK_REGISTERS = {
+    'FIO': 6700,
+    'EIO': 6701,
+    'CIO': 6702, # Note: 4 pins, only supports values 0-15
+}
+
+
+def get_trigger_port():
+    """Retrieves a TriggerPort object for writing digital trigger codes.
+
+    If a supported hardware trigger port is available, it will be
+    initialized and configured for sending trigger codes. If no digital
+    trigger hardware is available, a virtual trigger port will be returned.
+
+    """
+    # Try loading the LabLack U3 as a trigger port
+    if package_available('u3'):
+        import u3
+        if u3.deviceCount(devType=3) > 0:
+            return U3Port()
+
+    # If no physical trigger port available, return a virtual one
+    return VirtualPort()
+
+
+
+class TriggerPort(object):
+    """A class for sending digital trigger codes to external hardware.
+
+    """
+    def __init__(self):
+        # NOTE: Codes may be implementation-specific to allow for preprocessing
+        self.codes = {}
+        self._device = None
+        self._hardware_init()
+
+    def _hardware_init(self):
+        # Initialize the hardware for the trigger device & assign it to
+        # self._device.
+        pass
+
+    def add_code(self, name, value):
+        """Adds a new code to the list of triggers.
+
+        Once a trigger code has been added, it can be written to the trigger
+        port using the ``write`` method. Trigger codes must be whole numbers
+        between 0 and 255, inclusive.
+
+        Args:
+            name (str): The name of the trigger code (e.g. 'trial_start').
+            value (int): The digital value to write for the trigger code.
+
+        """
+        if not isinstance(value, int) or not (0 <= value <= 255):
+            e = "Trigger codes must be whole numbers between 0 and 255, inclusive"
+            raise ValueError(e + " (got {0})".format(value))
+        self.codes[name] = value
+
+    def add_codes(self, mapping):
+        """Adds a set of codes to the list of triggers.
+
+        For example::
+
+           trigger.add_codes({
+               'trial_start': 4,
+               'figure_on': 8,
+               'trial_end': 12,
+           })
+
+        Args:
+            mapping (dict): A dictionary in the form ``{'name': value}``
+                containing the names and digital triggers to add.
+
+        """
+        for name, value in mapping.items():
+            self.add_code(name, value)
+
+    def send(self, name, duration=4):
+        """Sends a given trigger code to the trigger port.
+
+        This method sends the requested trigger code to the hardware, waits a
+        given duration (default: 4ms), and then resets the trigger pins to 0.
+        The wait interval is because some hardware requires a delay between
+        sending the 'trigger on' and 'trigger off' signals to reliably detect
+        the triggers.
+
+        Args:
+            name (str): The name of the trigger code to write to the port.
+            duration (int, optional): The number of milliseconds to wait between
+                writing the trigger code and resetting the trigger pins to 0.
+                Defaults to 4 ms.
+        
+        """
+        self._write_trigger(self.codes[name])
+        time.sleep(duration / 1000.0)
+        self._write_trigger(0)
+
+    def _write_trigger(self, value, duration):
+        # Device-specific trigger code implementation. This actually sends a
+        # given code to the hardware.
+        pass
+
+
+
+class U3Port(TriggerPort):
+    """A TriggerPort implementation for LabJack U3 devices.
+
+    """
+    def _hardware_init(self):
+        import u3
+        self._device = u3.U3()
+        self._device.getCalibrationData()
+        self._write_reg = LABJACK_REGISTERS[P.labjack_port]
+        # TODO: Ensure requested port configured as digital out
+
+    def _write_trigger(self, value, duration):
+        # Fast method from Appelhoff & Stenner (2021), may be erratic on Windows
+        self._device.writeRegister(self.write_reg, 0xFF + value)
+
+
+
+class VirtualPort(TriggerPort):
+    
+    def _hardware_init(self):
+        print("\nNOTE: No hardware trigger device, using virtual triggers...\n")
+

--- a/ExpAssets/Resources/code/communication.py
+++ b/ExpAssets/Resources/code/communication.py
@@ -118,9 +118,14 @@ class U3Port(TriggerPort):
 
     """
     def _hardware_init(self):
-        self._device.getCalibrationData()
         self._write_reg = LABJACK_REGISTERS[P.labjack_port]
-        # TODO: Ensure requested port configured as digital out
+        self._device.getCalibrationData()
+        # Configure all IO pins to be digital outputs set to 0
+        self._device.configU3(
+            FIODirection=255, FIOState=0, FIOAnalog=0,
+            EIODirection=255, EIOState=0, EIOAnalog=0,
+            CIODirection=255, CIOState=0,
+        )
 
     def _write_trigger(self, value):
         # Fast method from Appelhoff & Stenner (2021), may be erratic on Windows

--- a/ExpAssets/Resources/code/communication.py
+++ b/ExpAssets/Resources/code/communication.py
@@ -47,8 +47,7 @@ class TriggerPort(object):
         self._hardware_init()
 
     def _hardware_init(self):
-        # Initialize the hardware for the trigger device & assign it to
-        # self._device.
+        # Initialize the hardware for the trigger device
         pass
 
     def add_code(self, name, value):

--- a/experiment.py
+++ b/experiment.py
@@ -233,6 +233,12 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 				fig_path = os.path.join(P.resources_dir, "figures", f)
 				self.test_figures[f] = TraceLabFigure(fig_path)
 
+		# Initialize trigger port
+		if P.requires_triggers:
+			from communication import get_trigger_port
+			self.trigger = get_trigger_port()
+			self.trigger.add_codes(P.trigger_codes)
+
 
 	def block(self):
 


### PR DESCRIPTION
This PR adds a proper user-facing API for sending trigger codes in TraceLab. It is intended to make it easier to add EMG/EEG/TMS triggers in future projects without anyone needing to dig into the LabJack docs.

Basically, if you set `requires_triggers` to `True` in the params file, TraceLab will automatically create a TriggerPort device as `self.trigger` in the Experiment class and will initialize it with any trigger code/value pairs listed in the params file, e.g.

```python
#########################################
# Digital Trigger Configuration
#########################################
requires_triggers = False
labjack_port = 'FIO' # Either FIO, EIO, or CIO
trigger_codes = {
    'trial_start': 2,
    'figure_on': 4,
    'circle_on': 6,
}
```

Then, in the body of the code, they can be sent like this:

```python
self.trigger.send('trial_start')
```

### Main features

* Trigger code names/values easily specified/customized in `params.py`
* Falls back to a virtual port if LabJackPython not installed or no LabJack devices connected (useful for testing without hardware)
* Written to allow for multiple backends (future-proofing for any equipment changes in the lab, or adapting for collaborators in other labs with different equipment)

NOTE: This code is currently completely untested with real hardware.