### PR TITLE
Add TMSController API for TMS communication/configuration

### DIFF
--- a/ExpAssets/Config/TraceLab_params.py
+++ b/ExpAssets/Config/TraceLab_params.py
@@ -28,6 +28,12 @@ trigger_codes = {
 }
 
 #########################################
+# TMS Configuration
+#########################################
+requires_tms = False
+tms_serial_port = '/dev/ttyUSB0'
+
+#########################################
 # Environment Aesthetic Defaults
 #########################################
 default_fill_color = (0, 0, 0, 255)

--- a/ExpAssets/Resources/code/communication.py
+++ b/ExpAssets/Resources/code/communication.py
@@ -217,6 +217,11 @@ class TMSController(object):
         """Arms the stimulator.
 
         Must be called at least one second before the stimulator can be fired.
+        Note that the stimulator will stay armed after firing, so you may need
+        to manually disarm between trials depending on the nature of your study.
+
+        Once armed, the Magstim will disarm automatically if the stimulator has
+        not been fired for over 1 minute.
  
         Args:
             wait (bool, optional): If True, this method will wait up to 2 seconds
@@ -266,12 +271,12 @@ class VirtualTMSController(TMSController):
     """
     def _hardware_init(self):
         self._info = {
-            'pwr_a': 0, 'pwr_b': 0, 'interval': 0, 'armed': False,
+            'pwr_a': 30, 'pwr_b': 30, 'interval': 30, 'armed': False,
         }
 
     def set_power(self, a, b=0):
         self._info['pwr_a'] = a
-        self._info['pwr_a'] = b
+        self._info['pwr_b'] = b
 
     def set_pulse_interval(self, duration):
         self._info['interval'] = duration

--- a/ExpAssets/Resources/code/communication.py
+++ b/ExpAssets/Resources/code/communication.py
@@ -48,9 +48,12 @@ def get_tms_controller():
     """
     if package_available('magpy'):
         # NOTE: Currently no way of autodetecting Magstim model
-        import magpy
-        dev = magpy.BiStim(P.tms_serial_port)
-        return MagstimController(dev)
+        from serial.tools.list_ports import comports
+        available_ports = [p.device for p in comports()]
+        if P.tms_serial_port in available_ports:
+            import magpy
+            dev = magpy.BiStim(P.tms_serial_port)
+            return MagstimController(dev)
     
     # If no hardware stimulator available, return a virtual one
     return VirtualTMSController(None)

--- a/ExpAssets/Resources/code/communication.py
+++ b/ExpAssets/Resources/code/communication.py
@@ -304,6 +304,7 @@ class VirtualTMSController(TMSController):
         self._info = {
             'pwr_a': 30, 'pwr_b': 0, 'interval': 0, 'armed': False,
         }
+        print("\nNOTE: No TMS hardware connected, using virtual stimulator...\n")
 
     def _set_power(self, level):
         self._info['pwr_a'] = level

--- a/ExpAssets/Resources/code/communication.py
+++ b/ExpAssets/Resources/code/communication.py
@@ -73,9 +73,9 @@ def get_tms_controller():
         from serial.tools.list_ports import comports
         available_ports = [p.device for p in comports()]
         if P.tms_serial_port in available_ports:
-            import magpy
+            from magpy.magstim import BiStim
             _poke_magstim(P.tms_serial_port)
-            dev = magpy.BiStim(P.tms_serial_port)
+            dev = BiStim(P.tms_serial_port)
             return MagPyController(dev)
     
     # If no hardware stimulator available, return a virtual one

--- a/ExpAssets/Resources/code/communication.py
+++ b/ExpAssets/Resources/code/communication.py
@@ -262,7 +262,7 @@ class TMSController(object):
         if wait:
             timeout = 2.0
             start = time.time()
-            while not self.armed:
+            while not self.ready:
                 time.sleep(0.1)
                 if (time.time() - start) > timeout:
                     e = "Arming the stimulator timed out (2 seconds)"
@@ -283,12 +283,6 @@ class TMSController(object):
         tasks where precise timing is not important. In all other cases,
         the stimulator should be triggered via TTL using a TriggerPort object.
 
-        """
-        pass
-
-    @property
-    def armed(self):
-        """bool: True if the stimulator is currently armed, otherwise False.
         """
         pass
 
@@ -328,10 +322,6 @@ class VirtualTMSController(TMSController):
 
     def fire(self):
         pass
-
-    @property
-    def armed(self):
-        return self._info['armed']
 
     @property
     def ready(self):
@@ -375,10 +365,6 @@ class MagPyController(TMSController):
 
     def fire(self):
         self._device.fire()
-
-    @property
-    def armed(self):
-        return self._device.isArmed()
 
     @property
     def ready(self):

--- a/ExpAssets/Resources/code/communication.py
+++ b/ExpAssets/Resources/code/communication.py
@@ -326,13 +326,13 @@ class MagPyController(TMSController):
     def _hardware_init(self):
         self._device.connect()
         # If BiStim, configure to start in single-pulse mode
-        err, msg = self._device.highResolutionMode(False, reciept=True)
+        err, msg = self._device.highResolutionMode(False, receipt=True)
         if err != 3:
             self._device.setPowerB(0)
             self._device.setPulseInterval(0)
 
     def _set_power(self, level):
-        err, msg = self._device.setPower(a, receipt=True)
+        err, msg = self._device.setPower(level, receipt=True)
         if err:
             _raise_err("setting power for the primary coil", msg)
 

--- a/experiment.py
+++ b/experiment.py
@@ -233,11 +233,16 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 				fig_path = os.path.join(P.resources_dir, "figures", f)
 				self.test_figures[f] = TraceLabFigure(fig_path)
 
-		# Initialize trigger port
+		# Initialize trigger port (if required)
 		if P.requires_triggers:
 			from communication import get_trigger_port
 			self.trigger = get_trigger_port()
 			self.trigger.add_codes(P.trigger_codes)
+
+		# Initialize TMS communication (if required)
+		if P.requires_tms:
+			from communication import get_tms_controller
+			self.magstim = get_tms_controller()
 
 
 	def block(self):


### PR DESCRIPTION
This PR adds an abstracted `TMSController` class with basic TMS control/configuration methods like `set_power`, `arm`, `disarm`, and TMS state attributes like `armed` and `ready`.

Like with the TriggerPort API, this is designed to connect to real hardware if a) `P.requires_tms` is True, b) `magpy` is installed, and c) a magstim can be successfully connected to at the given serial port (`P.tms_serial_port`). If A is true but B or C are not, `get_tms_controller` will quietly fall back to a virtual TMSController that has all the same methods/attributes as a MagstimController but doesn't actually do anything.

If `P.requires_tms` is True, a TMSController will be created automatically during TraceLab setup as `self.magstim`, which can be used like:

```python
self.magstim.set_power(50)
self.magstim.arm(wait=True)
if self.magstim.ready:
    self.trigger("tms_fire") # Firing actually done through TriggerPort
```

The main thing missing here is a way of checking current power levels (or a flag to `set_power` to wait until power levels match the requested values), since actually increasing/decreasing the power level can be pretty slow on the stimulator.

Also, since magpy has no way of checking device model, this is currently hard-coded to assume we're connecting to a BiStim (fine for now, but good to fix eventually).

Unsure if it's worth adding an 'allow_fallback' parameter to make sure the Magstim (or LabJack) connections never silently fail during actual data collection.