### PR TITLE
Rewrite figure saving code

### DIFF
--- a/ExpAssets/Config/TraceLab_params.py
+++ b/ExpAssets/Config/TraceLab_params.py
@@ -130,15 +130,6 @@ slope_magnitude = (0.25, 0.5)  # 0 = a straight line (ie. no curve), 1 = an infi
 peak_shift = (0.25, 0.5)  # 0 == perfect symmetry (ie. bell curve) and 1 == a right  triangle
 curve_sheer = (0.1, 0.3)  # this is hard to describe, but 1 is again an impossible value, and this will grow to lunacy fast
 
-########################################
-# tlf Controls
-########################################
-gen_tlfx = True  # extended (5s) interpolation
-gen_tlfs = True  # segments file
-gen_tlfp = True  # points file
-gen_png = True   # image file
-gen_ext_png = False  # image file from extended interpolation
-
 #########################################
 # Data Export Settings
 #########################################

--- a/README.md
+++ b/README.md
@@ -109,8 +109,7 @@ File | Description
 `.tlf` | A text file containing the (x, y) pixel coordinates and timestamps for each frame of the figure animated on the trial.
 `.tlfp` | A text file containing the (x, y) pixel coordinates of the vertices of the figure animated on the trial.
 `.tlfs` | A text file containing the (x, y) pixel coordinates of the start/end/control points for each segment of the figure animated on the trial.
-`.tlfx` | A text file containing the (x, y) pixel coordinates for each frame of the trial figure, as if rendered at a duration of 5 seconds.
-`.tlt` | A text file containing the (x, y) pixel coordinates and timestamps for each sample of a recorded response tracing for a physical trial.
+`.tlt` | A text file containing the (x, y) pixel coordinates and timestamps for each sample of a recorded tracing response (physical trials only).
 
 Additionally, the file name for each trial's `.zip` contains the (p)articipant id number, (s)ession number, (b)lock number, (t)rial number and date for the trial. For example, `p1_s2_b1_t3_2018-11-30.zip` would contain the data for block 1, trial 3 of session 2 (recorded on November 30, 2018) for the participant whose database ID is 1.
 

--- a/experiment.py
+++ b/experiment.py
@@ -24,7 +24,7 @@ from klibs.KLCommunication import user_queries, message, query
 from klibs.KLResponseCollectors import DrawResponse
 
 from TraceLabSession import TraceLabSession
-from TraceLabFigure import TraceLabFigure
+from TraceLabFigure import TraceLabFigure, save_figure
 from ButtonBar import ButtonBar
 from KeyFrames import FrameSet
 
@@ -310,9 +310,9 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 		self.rt = 0.0
 		self.it = 0.0
 		self.animate_time = int(self.animate_time)
-		self.drawing = 'NA'
 		self.control_response = -1
 		self.figure = None
+		self.drawing = None
 
 		# Either load a pre-generated figure or generate a new one, depending on trial
 		if self.figure_name == "random":
@@ -389,8 +389,8 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 	def trial_clean_up(self):
 
 		if not self.__practicing__:
-			self.figure.write_out(self.file_name + ".tlf")
-			self.figure.write_out(self.file_name + ".tlt", self.drawing)
+			outpath = os.path.join(self.fig_dir, self.file_name + ".zip")
+			save_figure(outpath, self.figure, self.drawing)
 		self.rc.draw_listener.reset()
 		self.control_bar.reset()
 
@@ -599,7 +599,9 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 				flip()
 
 				figure = self._generate_figure(duration=5000.0)
-				figure.write_out("figure{0}_{1}.tlf".format(i + 1, P.random_seed))
+				outfile = "figure{0}_{1}.zip".format(i + 1, P.random_seed)
+				outpath = os.path.join(self.fig_dir, outfile)
+				save_figure(outpath, figure)
 
 		else:
 
@@ -637,22 +639,24 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 						done = True
 						break
 					elif resp == "s": # save
-						f_name = query(user_queries.experimental[7]) + ".tlf"
+						outfile = query(user_queries.experimental[7]) + ".zip"
+						outpath = os.path.join(self.fig_dir, outfile)
 						msg = message("Saving... ", blit_txt=False)
 						fill()
 						blit(msg, 5, P.screen_c)
 						flip()
-						figure.write_out(f_name)
+						save_figure(outpath, figure)
 						break
 
 
 	def capture_learned_figure(self, fig_number):
 
 		self.evm.start()
-		fig_name = "p{0}_learned_figure_{1}.tlt".format(P.participant_id, fig_number)
+		outfile = "p{0}_learned_figure_{1}.zip".format(P.participant_id, fig_number)
+		outpath = os.path.join(self.fig_dir, outfile)
 		self.rc.draw_listener.reset()
 		self.rc.collect()
-		self.figure.write_out(fig_name, self.rc.draw_listener.responses[0][0])
+		save_figure(outpath, tracing=self.rc.draw_listener.responses[0][0])
 		self.evm.reset()
 
 


### PR DESCRIPTION
Closes #5. 

This PR replaces the `write_out` method of the TraceLabFigure class with a simpler/cleaner `save_figure` function that's able to save figures and tracing data at the same time. This fixes the rare but deeply annoying bug where multiple figures/tracings with the same file names could be saved within the same .zip, because figure .zips no longer need to be opened in "append if already exists" mode instead of "overwrite if already exists" mode to accommodate the need to call `write_out` separately for figures and tracings.

This PR also removes the generation of `.tlfx` files (extended interpolations of figures at 5000 ms speeds) as these can be generated in TraceLabAnalysis if needed using the `.tlfs` segments data, as well as the "extended" PNGs which serve little purpose and can likewise be generated using the R scripts if needed.