### PR TITLE
Fix parsing of feedback conditions

### DIFF
--- a/ExpAssets/Config/TraceLab_params.py
+++ b/ExpAssets/Config/TraceLab_params.py
@@ -155,8 +155,8 @@ exclude_data_cols = [
 #
 # Feedback types:
 #  - "X" / "XX"  (no feedback)
-#  - "R" / "XR"  (live tracing feedback during tracing response)
-#  - "V" / "VX"  (presentation of target figure with tracing overlay after response made)
+#  - "V" / "VX"  (live tracing feedback during tracing response)
+#  - "R" / "XR"  (presentation of target figure with tracing overlay after response made)
 #  - "VR"        (both "R" and "V")
 #
 # Custom trial counts:

--- a/ExpAssets/Resources/code/TraceLabSession.py
+++ b/ExpAssets/Resources/code/TraceLabSession.py
@@ -465,14 +465,14 @@ class TraceLabSession(EnvAgent):
 		resp_map = {'PP': PHYS, 'MI': MOTR, 'CC': CTRL}
 		resp = resp_map[response]
 
-		if "X" in feedback:
-			fb = "False"
-		elif "V" in feedback and "R" in feedback:
+		if "V" in feedback and "R" in feedback:
 			fb = FB_ALL
 		elif "R" in feedback:
 			fb = FB_RES
 		elif "V" in feedback:
 			fb = FB_DRAW
+		else:
+			fb = "False"
 
 		return [resp, fb]
 


### PR DESCRIPTION
This patch fixes the documentation of the different physical feedback conditions (the description in the params file had V and R backwards), as well as the actual parsing of conditions (without this fix, any condition containing an X was parsed as 'no feedback', breaking 'VX' and 'XR' condition codes).