### PR TITLE
New options, tweaks, and cleanup

### DIFF
--- a/ExpAssets/Config/TraceLab_params.py
+++ b/ExpAssets/Config/TraceLab_params.py
@@ -13,6 +13,7 @@ run_practice_blocks = False
 demo_mode = False
 mirror_mode = False
 enable_learned_figures_querying = True
+use_figure_sets = False
 
 capture_figures_mode = False
 auto_generate = False  # whether to generate figures without prompting in capture mode

--- a/ExpAssets/Config/TraceLab_params.py
+++ b/ExpAssets/Config/TraceLab_params.py
@@ -9,6 +9,7 @@ collect_demographics = True
 manual_demographics_collection = True
 manual_trial_generation = True
 run_practice_blocks = False
+force_show_cursor = False # If False, cursor hidden unless in devmode & no touchscreen
 
 demo_mode = False
 mirror_mode = False
@@ -77,7 +78,7 @@ bubble_location = (1550, 275)
 dm_auto_threshold = True
 dm_render_progress = False  # if True, drawing feedback will always be shown in devmode
 dm_ignore_local_overrides = False
-dm_always_show_cursor = True
+dm_trial_show_mouse = False
 use_log_file = False  # Not sure this is terribly useful
 
 ########################################

--- a/ExpAssets/Config/TraceLab_params.py
+++ b/ExpAssets/Config/TraceLab_params.py
@@ -15,6 +15,7 @@ demo_mode = False
 mirror_mode = False
 enable_learned_figures_querying = True
 use_figure_sets = False
+show_figure_at_onset = False
 
 capture_figures_mode = False
 auto_generate = False  # whether to generate figures without prompting in capture mode

--- a/ExpAssets/Config/TraceLab_params.py
+++ b/ExpAssets/Config/TraceLab_params.py
@@ -140,6 +140,7 @@ unique_identifier = "user_id"
 exclude_data_cols = [
     'klibs_commit', 'created', 'session_count', 'sessions_completed', 'initialized'
 ]
+append_hostname = False
 
 #########################################
 # Session & Block Structures

--- a/ExpAssets/Config/TraceLab_schema.sql
+++ b/ExpAssets/Config/TraceLab_schema.sql
@@ -44,7 +44,7 @@ to be an integer.
 CREATE TABLE participants (
 	id                 INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
 	user_id            INTEGER                           NOT NULL UNIQUE,
-	sex                TEXT                              NOT NULL,
+	gender             TEXT                              NOT NULL,
 	age                INTEGER                           NOT NULL,
 	handedness         TEXT                              NOT NULL,
 	session_structure  TEXT,

--- a/ExpAssets/Config/TraceLab_user_queries.json
+++ b/ExpAssets/Config/TraceLab_user_queries.json
@@ -47,10 +47,10 @@
 		},
 		{
 			"index": 2,
-			"title": "sex",
-			"database_field": "sex",
-			"query": "What is your sex?\nAnswer with: (m)ale or (f)emale",
-			"accepted": ["m", "f"],
+			"title": "gender",
+			"database_field": "gender",
+			"query": "What is your gender?\nAnswer with: (m)ale, (f)emale, or (n)on-binary",
+			"accepted": ["m", "f", "n"],
 			"allow_null": false,
 			"format": {
 				"type": "str",
@@ -62,7 +62,7 @@
 				"accept_as_true": null,
 				"action": null
 			},
-			"anonymous_value": "EVAL: 'm' if now() % 2 > 0  else 'f'",
+			"anonymous_value": "n",
 			"active": true
 		},
 		{

--- a/ExpAssets/Resources/Text/control_group_instructions.txt
+++ b/ExpAssets/Resources/Text/control_group_instructions.txt
@@ -1,3 +1,0 @@
-Remember to take your time!
-
-Tap the screen to begin.

--- a/ExpAssets/Resources/Text/imagery_group_instructions.txt
+++ b/ExpAssets/Resources/Text/imagery_group_instructions.txt
@@ -1,3 +1,0 @@
-Remember to match the speed!
-
-Tap the screen to begin.

--- a/ExpAssets/Resources/Text/physical_group_instructions.txt
+++ b/ExpAssets/Resources/Text/physical_group_instructions.txt
@@ -1,3 +1,0 @@
-Remember to match the speed!
-
-Tap the screen to begin.

--- a/ExpAssets/Resources/code/ButtonBar.py
+++ b/ExpAssets/Resources/code/ButtonBar.py
@@ -9,7 +9,7 @@ from klibs.KLGraphics.KLDraw import Rectangle, Ellipse
 from klibs.KLCommunication import message
 from klibs.KLBoundary import BoundaryInspector, RectangleBoundary
 from klibs.KLEventQueue import pump, flush
-from klibs.KLUserInterface import ui_request, mouse_clicked, show_cursor, hide_cursor
+from klibs.KLUserInterface import ui_request, mouse_clicked
 from klibs.KLEnvironment import EnvAgent
 
 
@@ -149,11 +149,9 @@ class ButtonBar(EnvAgent):
 
 	def init(self):
 		flush()
-		show_cursor()
 		self._loop_start = self._timestamp()
 
 	def cleanup(self):
-		hide_cursor()
 		for b in self.buttons:
 			b.active = False
 		if self.finish_b:

--- a/ExpAssets/Resources/code/TraceLabSession.py
+++ b/ExpAssets/Resources/code/TraceLabSession.py
@@ -186,7 +186,7 @@ class TraceLabSession(EnvAgent):
 		P.blocks_per_experiment = len(P.session_structures[structure_key][0])
 
 		# Query user whether they want to select a figure set by name for the participant
-		if query(uq.experimental[2]) == "y":
+		if P.use_figure_sets and query(uq.experimental[2]) == "y":
 			self.exp.figure_set_name = self.__get_figure_set_name()
 
 		# Collect user demographics and retrieve user id from database

--- a/ExpAssets/Resources/code/TraceLabSession.py
+++ b/ExpAssets/Resources/code/TraceLabSession.py
@@ -25,6 +25,7 @@ from klibs.KLCommunication import query, message, collect_demographics
 from klibs.KLCommunication import user_queries as uq
 
 from FigureSet import FigureSet
+from utils import get_hostname
 
 
 PHYS = "physical"
@@ -311,7 +312,11 @@ class TraceLabSession(EnvAgent):
 				self.exp.quit()
 
 		# Initialize figure paths for current participant/session
-		p_dir = "p{0}_{1}".format(P.participant_id, self.exp.created)
+		date = self.exp.created.split("_")[0]
+		p_dir = "p{0}_{1}".format(P.participant_id, date)
+		if P.append_hostname:
+			hostname = get_hostname()
+			p_dir += "-{0}".format(hostname)
 		session_dir = "session_" + str(self.exp.session_number)
 		self.exp.p_dir = os.path.join(P.data_dir, p_dir)
 		self.exp.fig_dir = os.path.join(self.exp.p_dir, session_dir)

--- a/ExpAssets/Resources/code/TraceLabSession.py
+++ b/ExpAssets/Resources/code/TraceLabSession.py
@@ -10,9 +10,9 @@ import os
 import io
 import sys
 import shutil
-from imp import load_source
 
 from klibs import P
+from klibs.KLInternal import load_source
 from klibs.KLEnvironment import EnvAgent
 from klibs.KLJSON_Object import AttributeDict
 from klibs.KLUtilities import now, utf8
@@ -141,21 +141,19 @@ class TraceLabSession(EnvAgent):
 
 	def __import_figure_sets(self):
 
-		# load original complete set of FigureSets for use
-		fig_sets_f = os.path.join(P.config_dir, "figure_sets.py")
-		fig_sets_local_f = os.path.join(P.local_dir, "figure_sets.py")
-		try:
-			sys.path.append(fig_sets_local_f)
-			for k, v in load_source("*", fig_sets_local_f).__dict__.items():
-				if isinstance(v, FigureSet):
-					self.exp.figure_sets[v.name] = v
-			if P.dm_ignore_local_overrides:
-				raise RuntimeError("ignoring local files")
-		except (IOError, RuntimeError):
-			sys.path.append(fig_sets_f)
-			for k, v in load_source("*", fig_sets_f).__dict__.items():
-				if isinstance(v, FigureSet):
-					self.exp.figure_sets[v.name] = v
+		# Load figure sets for project
+		set_path = os.path.join(P.config_dir, "figure_sets.py")
+		tst = load_source(set_path)
+		for var, value in load_source(set_path).items():
+			if isinstance(value, FigureSet):
+				self.exp.figure_sets[value.name] = value
+
+		# Load any local overrides for the figure sets
+		set_path_local = os.path.join(P.local_dir, "figure_sets.py")
+		if os.path.exists(set_path_local) and not P.dm_ignore_local_overrides:
+			for var, value in load_source(set_path_local).items():
+				if isinstance(value, FigureSet):
+					self.exp.figure_sets[value.name] = value
 
 
 	def __generate_user_id(self):

--- a/ExpAssets/Resources/code/utils.py
+++ b/ExpAssets/Resources/code/utils.py
@@ -1,0 +1,14 @@
+import sdl2
+
+
+def touchscreen_detected():
+	# Attempts to detect any available touchscreens
+	n = sdl2.SDL_GetNumTouchDevices()
+	# NOTE: On Windows, touchscreen must be touched at least once after task
+    # start for it to be detected as a touch device
+	for i in range(n):
+		dev = sdl2.SDL_GetTouchDevice(i)
+		devtype = sdl2.SDL_GetTouchDeviceType(dev)
+		if devtype == sdl2.SDL_TOUCH_DEVICE_DIRECT:
+			return True
+	return False

--- a/ExpAssets/Resources/code/utils.py
+++ b/ExpAssets/Resources/code/utils.py
@@ -1,3 +1,4 @@
+import socket
 import sdl2
 
 
@@ -12,3 +13,11 @@ def touchscreen_detected():
 		if devtype == sdl2.SDL_TOUCH_DEVICE_DIRECT:
 			return True
 	return False
+
+
+def get_hostname():
+    # Gets and sanitizes the hostname of the current computer
+	hostname = socket.gethostname()
+	for a, b in [(".local", ""), ("DESKTOP-", ""), (" ", "-")]:
+		hostname = hostname.replace(a, b)
+	return hostname

--- a/experiment.py
+++ b/experiment.py
@@ -202,10 +202,16 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 		self.add_boundary("next trial button", bounds, RECT_BOUNDARY)
 
 		# Initialize instructions and practice button bar for each condition
+		block_msg_tmp = "Remember to {0}!\n\nTap the screen to begin."
+		self.block_messages = {
+			PHYS: block_msg_tmp.format("match the speed"),
+			MOTR: block_msg_tmp.format("match the speed"),
+			CTRL: block_msg_tmp.format("take your time"),
+		}
 		self.instruction_files = {
-			PHYS: {'text': "physical_group_instructions.txt", 'frames': "physical_key_frames"},
-			MOTR: {'text': "imagery_group_instructions.txt", 'frames': "imagery_key_frames"},
-			CTRL: {'text': "control_group_instructions.txt", 'frames': "control_key_frames"}
+			PHYS: {'frames': "physical_key_frames"},
+			MOTR: {'frames': "imagery_key_frames"},
+			CTRL: {'frames': "control_key_frames"}
 		}
 		self.practice_instructions = message(
 			P.practice_instructions, "instructions",
@@ -244,9 +250,6 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 
 			# Load instructions for new response type
 			new_instructions = self.instruction_files[self.response_type]
-			instructions_file = os.path.join(P.resources_dir, "Text", new_instructions['text'])
-			inst_txt = io.open(instructions_file, encoding='utf-8').read()
-			self.instructions = message(inst_txt, "instructions", align="center", blit_txt=False)
 
 			if P.enable_practice:
 				# Load tutorial animation for current condition, play it, and enter practice
@@ -263,12 +266,14 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 
 			self.prev_response_type = self.response_type
 
+		block_msg_txt = self.block_messages[self.response_type]
+		block_msg = message(block_msg_txt, "instructions", align="center")
 		for i in range(1,4):
 			# we do this a few times to avoid block messages being skipped due to duplicate input
 			# from the touch screen we use
 			ui_request()
 			fill()
-			blit(self.instructions, registration=5, location=P.screen_c, flip_x=P.flip_x)
+			blit(block_msg, 5, P.screen_c, flip_x=P.flip_x)
 			flip()
 		any_key()
 

--- a/experiment.py
+++ b/experiment.py
@@ -24,7 +24,7 @@ from klibs.KLResponseCollectors import DrawResponse
 
 from TraceLabSession import TraceLabSession
 from TraceLabFigure import TraceLabFigure, save_figure
-from utils import touchscreen_detected
+from utils import touchscreen_detected, get_hostname
 from ButtonBar import ButtonBar
 from KeyFrames import FrameSet
 
@@ -168,6 +168,10 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 		# Initialize participant ID and session options, reloading ID if it already exists
 		self.session = TraceLabSession()
 		self.user_id = self.session.user_id
+		self.filename_id = str(P.participant_id)
+		if P.append_hostname:
+			self.filename_id += "-{0}".format(get_hostname())
+
 
 		# Add flags for first block/trial of run, needed for resuming mid-session
 		self.first_block = True
@@ -643,7 +647,7 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 	def capture_learned_figure(self, fig_number):
 
 		self.evm.start()
-		outfile = "p{0}_learned_figure_{1}.zip".format(P.participant_id, fig_number)
+		outfile = "p{0}_learned_figure_{1}.zip".format(self.filename_id, fig_number)
 		outpath = os.path.join(self.fig_dir, outfile)
 		self.rc.draw_listener.reset()
 		self.rc.collect()
@@ -681,7 +685,7 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 	@property
 	def file_name(self):
 		file_name_data = [
-			P.participant_id, P.block_number, P.trial_number,
+			self.filename_id, P.block_number, P.trial_number,
 			now(True, "%Y-%m-%d"), self.session_number
 		]
 		return "p{0}_s{4}_b{1}_t{2}_{3}".format(*file_name_data)

--- a/experiment.py
+++ b/experiment.py
@@ -4,6 +4,7 @@ __author__ = "Jonathan Mulle"
 import os
 import io
 import time
+import sdl2
 
 from random import choice
 from sdl2 import SDL_MOUSEBUTTONDOWN, SDL_KEYDOWN
@@ -13,9 +14,8 @@ from klibs import P
 from klibs.KLConstants import RECT_BOUNDARY, CIRCLE_BOUNDARY, STROKE_OUTER, QUERY_UPD
 from klibs.KLBoundary import BoundaryInspector
 from klibs.KLTime import CountDown
-from klibs.KLUserInterface import any_key, ui_request
-from klibs.KLUtilities import (pump, flush, scale, now, mouse_pos,
-	show_mouse_cursor, hide_mouse_cursor, utf8)
+from klibs.KLUserInterface import any_key, ui_request, show_cursor, hide_cursor
+from klibs.KLUtilities import pump, flush, scale, now, mouse_pos, utf8
 from klibs.KLUtilities import colored_stdout as cso
 from klibs.KLGraphics import blit, fill, flip
 from klibs.KLGraphics.KLDraw import Ellipse, Rectangle
@@ -25,6 +25,7 @@ from klibs.KLResponseCollectors import DrawResponse
 
 from TraceLabSession import TraceLabSession
 from TraceLabFigure import TraceLabFigure, save_figure
+from utils import touchscreen_detected
 from ButtonBar import ButtonBar
 from KeyFrames import FrameSet
 
@@ -222,6 +223,15 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 			[200, 100], P.btn_s_pad, P.y_pad, finish_button=False
 		)
 
+		# Determine whether cursor should be shown or hidden
+		touchscreen = touchscreen_detected()
+		if P.force_show_cursor or (P.development_mode and not touchscreen):
+			self.show_cursor = True
+			show_cursor()
+		else:
+			self.show_cursor = False
+			hide_cursor()
+
 		# Import all pre-generated figures needed for the current session
 		figures = list(set(self.trial_factory.exp_factors["figure_name"]))
 		figures.append(P.practice_figure)
@@ -284,16 +294,12 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 		self.rc.terminate_after = [120, klibs.TK_S] # Wait really long before timeout
 		self.rc.draw_listener.start_boundary = 'start'
 		self.rc.draw_listener.stop_boundary = 'stop'
-		self.rc.draw_listener.show_active_cursor = False
-		self.rc.draw_listener.show_inactive_cursor = True
+		self.rc.draw_listener.show_active_cursor = self.show_cursor
+		self.rc.draw_listener.show_inactive_cursor = self.show_cursor
 		self.rc.draw_listener.origin = self.origin_pos
 		self.rc.draw_listener.interrupts = True
 		self.rc.draw_listener.min_samples = 5
 		self.rc.display_callback = self.display_refresh
-
-		if P.dm_always_show_cursor:
-			self.rc.draw_listener.show_active_cursor = True
-			self.rc.draw_listener.show_inactive_cursor = True
 
 		if P.demo_mode or self.feedback_type in (FB_DRAW, FB_ALL):
 			self.rc.draw_listener.render_real_time = True
@@ -460,9 +466,6 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 		blit(self.next_trial_msg, 5, self.next_trial_button_loc, flip_x=P.flip_x)
 		flip()
 
-		if P.demo_mode or P.dm_always_show_cursor:
-			show_mouse_cursor()
-
 		flush()
 		clicked = False
 		while not clicked:
@@ -472,9 +475,6 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 					clicked = self.within_boundary("next trial button", [e.button.x, e.button.y])
 				elif e.type == SDL_KEYDOWN:
 					ui_request(e.key.keysym)
-
-		if not (P.demo_mode or P.dm_always_show_cursor):
-			hide_mouse_cursor()
 
 
 	def display_refresh(self):
@@ -498,9 +498,6 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 		flip()
 
 		start = time.perf_counter()
-		if P.demo_mode or P.dm_always_show_cursor:
-			show_mouse_cursor()
-
 		at_origin = False
 		while not at_origin:
 			x, y, button = mouse_pos(return_button_state=True)
@@ -519,8 +516,6 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 			if not (self.within_boundary('origin', (x, y)) and left_button_down):
 				at_origin = False
 		self.mt = time.perf_counter() - (self.rt + start)
-		if P.demo_mode:
-			hide_mouse_cursor()
 
 
 	def physical_trial(self):

--- a/experiment.py
+++ b/experiment.py
@@ -334,8 +334,8 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 		else:
 			self.figure = self.test_figures[self.figure_name]
 			self.figure.animate_target_time = self.animate_time
-			self.figure.render()
 			self.figure.prepare_animation()
+		self.figure.render()
 
 		# Initialize origin position and origin boundaries based on the loaded figure
 		self.origin_pos = list(self.figure.points[0])
@@ -358,6 +358,8 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 		while start_delay.counting():
 			ui_request()
 			fill()
+			if P.show_figure_at_onset:
+				blit(self.figure.rendered, 5, P.screen_c)
 			blit(self.tracker_dot, 5, self.origin_pos)
 			flip()
 

--- a/experiment.py
+++ b/experiment.py
@@ -7,14 +7,13 @@ import time
 import sdl2
 
 from random import choice
-from sdl2 import SDL_MOUSEBUTTONDOWN, SDL_KEYDOWN
 
 import klibs
 from klibs import P
 from klibs.KLConstants import RECT_BOUNDARY, CIRCLE_BOUNDARY, STROKE_OUTER, QUERY_UPD
-from klibs.KLBoundary import BoundaryInspector
+from klibs.KLBoundary import BoundaryInspector, RectangleBoundary
 from klibs.KLTime import CountDown
-from klibs.KLUserInterface import any_key, ui_request, show_cursor, hide_cursor
+from klibs.KLUserInterface import any_key, ui_request, show_cursor, hide_cursor, mouse_clicked
 from klibs.KLUtilities import pump, flush, scale, now, mouse_pos, utf8
 from klibs.KLUtilities import colored_stdout as cso
 from klibs.KLGraphics import blit, fill, flip
@@ -196,11 +195,14 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 		# Initialize 'next trial' button
 		button_x = 250 if self.handedness == LEFT_HANDED else P.screen_x - 250
 		button_y = P.screen_y - 100
-		self.next_trial_msg = message(P.next_trial_message, 'default', blit_txt=False)
-		self.next_trial_box = Rectangle(300, 75, stroke=(2, (255, 255, 255), STROKE_OUTER))
+		button_w, button_h = (300, 75)
+		xy1 = (button_x - button_w // 2, button_y - button_h // 2)
+		xy2 = (button_x + button_w // 2, button_y + button_h // 2)
+		self.next_trial_msg = message(P.next_trial_message, 'default')
+		self.next_trial_box = Rectangle(button_w, button_h, stroke=(2, WHITE, STROKE_OUTER))
 		self.next_trial_button_loc = (button_x, button_y)
-		bounds = [(button_x - 150, button_y - 38), (button_x + 150, button_y + 38)]
-		self.add_boundary("next trial button", bounds, RECT_BOUNDARY)
+		self.next_trial_bounds = RectangleBoundary("next trial", xy1, xy2)
+
 
 		# Initialize instructions and practice button bar for each condition
 		block_msg_tmp = "Remember to {0}!\n\nTap the screen to begin."
@@ -469,12 +471,7 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 		flush()
 		clicked = False
 		while not clicked:
-			event_queue = pump(True)
-			for e in event_queue:
-				if e.type == SDL_MOUSEBUTTONDOWN:
-					clicked = self.within_boundary("next trial button", [e.button.x, e.button.y])
-				elif e.type == SDL_KEYDOWN:
-					ui_request(e.key.keysym)
+			clicked = mouse_clicked(within=self.next_trial_bounds)
 
 
 	def display_refresh(self):

--- a/experiment.py
+++ b/experiment.py
@@ -356,6 +356,15 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 		else:
 			self.control_trial()
 
+		if self.feedback_type in (FB_ALL, FB_RES) and not self.__practicing__:
+			flush()
+			fill()
+			blit(self.figure.render(trace=self.drawing), 5, P.screen_c)
+			flip()
+			start = time.time()
+			while time.time() - start < P.feedback_duration / 1000.0:
+				ui_request()
+
 		fill()
 		flip()
 
@@ -516,15 +525,6 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 		self.drawing = self.rc.draw_listener.responses[0][0]
 		self.it = self.rc.draw_listener.first_sample_time - self.rt
 		self.mt = self.rc.draw_listener.responses[0][1]
-
-		if self.feedback_type in (FB_ALL, FB_RES) and not self.__practicing__:
-			flush()
-			fill()
-			blit(self.figure.render(trace=self.drawing), 5, P.screen_c, flip_x=P.flip_x)
-			flip()
-			start = time.time()
-			while time.time() - start < P.feedback_duration / 1000.0:
-				ui_request()
 
 
 	def control_trial(self):


### PR DESCRIPTION
This PR contains a number of minor tweaks and new options as well as some internal code cleanup/modernization.

### New Options
- The "would you like to use a figure set" query at the start of the task is now disabled by default since most studies don't use it. It can be re-enabled by setting `user_figure_sets` to True in `TraceLab_params.py`
- Results feedback has been enabled for all trial types, meaning that if results feedback is requested for an imagery trial the target shape will be shown briefly at the end of the trial.
- A new option `show_figure_at_onset` has been added which shows the rendered target figure on screen during the wait period prior to the dot animation at the start of each trial. Disabled by default.

### Other changes
- The demographics queries have been updated to ask participant gender instead of sex.
- The cursor visibility logic has been simplified and reworked throughout so that the cursor is only show if in development mode and no valid touchscreen device is detected. This can be overridden with `force_show_cursor`, which forces the cursor to always be shown on screen during the task.
- Support for group testing has been added, allowing data to be collected on multiple computers at once such that the data can be merged at the end for analysis. This can be enabled by setting the `append_hostname` parameter to True, which appends the name of the computer to participant data files in order to avoid id number conflicts.