### PR TITLE
Use custom ResponseListener for collecting draw responses

### DIFF
--- a/ExpAssets/Resources/code/responselisteners.py
+++ b/ExpAssets/Resources/code/responselisteners.py
@@ -3,9 +3,10 @@ import numpy as np
 import klibs.KLParams as P
 from klibs.KLTime import precise_time
 from klibs.KLBoundary import Boundary
-from klibs.KLUserInterface import mouse_pos
 from klibs.KLResponseListeners import BaseResponseListener
 from klibs.KLGraphics.utils import rgb_to_rgba, aggdraw_to_array
+
+from utils import get_touch_coords
 
 
 class DrawingListener(BaseResponseListener):
@@ -29,6 +30,7 @@ class DrawingListener(BaseResponseListener):
         self.points = []
         self._origin_touched = None
         self._drawing_start = None
+        self._was_drawing = False
 
     def _timestamp(self):
         # NOTE: precise_time seems to be more consistent than time.perf_counter here
@@ -62,6 +64,8 @@ class DrawingListener(BaseResponseListener):
         mt: Movement time, defined as the interval between the start of the
             drawing and the end of the drawing (return to origin).
 
+        .. NOTE: Drawing samples are only recorded when actually touching the screen.
+
         Returns:
             tuple: A ``(drawing, rt, it, mt)`` tuple containing the drawing trajectory
             and its reaction time, initiation time, and movement time.
@@ -89,8 +93,13 @@ class DrawingListener(BaseResponseListener):
             response been made, otherwise None.
 
         """
-        loc = mouse_pos()
+        loc = get_touch_coords()
         timestamp = self._timestamp()
+
+        # Check if actually touching the screen, ignore input if not
+        if not loc:
+            self._was_drawing = False
+            return None
 
         # If response not initiated, check if cursor is within origin and start if so
         if not self.started:
@@ -98,7 +107,7 @@ class DrawingListener(BaseResponseListener):
                 self._origin_touched = timestamp
 
         # If within origin after drawing start, end drawing if min duration has elapsed
-        elif self._drawing_start and loc in self.origin_boundary:
+        elif self._drawing_start and loc in self.origin_boundary and self._was_drawing:
             last_timestamp = self.points[-1][-1]
             if last_timestamp > self.min_duration and len(self.points) >= 2:
                 rt = round(self._origin_touched - self._loop_start, 4)
@@ -108,6 +117,7 @@ class DrawingListener(BaseResponseListener):
 
         # Once response is initiated and cursor leaves origin, start recording drawing
         if self.started and not loc in self.origin_boundary:
+            self._was_drawing = True
             if not self._drawing_start:
                 self._drawing_start = timestamp
                 p = (loc[0], loc[1], 0.0)
@@ -125,6 +135,7 @@ class DrawingListener(BaseResponseListener):
         self._loop_start = None
         self._origin_touched = None
         self._drawing_start = None
+        self._was_drawing = False
 
     @property
     def started(self):

--- a/ExpAssets/Resources/code/responselisteners.py
+++ b/ExpAssets/Resources/code/responselisteners.py
@@ -1,4 +1,5 @@
 import aggdraw
+import numpy as np
 import klibs.KLParams as P
 from klibs.KLTime import precise_time
 from klibs.KLBoundary import Boundary
@@ -142,14 +143,36 @@ class DrawingListener(BaseResponseListener):
         return self._timestamp() - self._drawing_start
 
 
-def render_tracing(points, color, thickness=1):
-    surf = aggdraw.Draw("RGBA", P.screen_x_y, (0, 0, 0, 0))
-    surf.setantialias(True)
-    color = rgb_to_rgba(color)
-    if len(points) >= 2:
-        m_str = "M{0},{1}".format(points[0][0], points[0][1])
-        for p in points[1:]:
-            m_str += "L{0},{1}".format(p[0], p[1])
-        s = aggdraw.Symbol(m_str)
-        surf.symbol((0, 0), s, aggdraw.Pen(color[:3], thickness, color[3]))
-    return aggdraw_to_array(surf)
+
+class DrawSurface(object):
+    """An optimized class for rendering live tracings.
+
+    To avoid the need to create a new surface and re-render the whole tracing every
+    frame, this class creates a single surface and updates it with new tracing data
+    as it comes in.
+
+    Necessary to avoid dropped frames when tracing feedback is enabled.
+
+    """
+    def __init__(self, size, color, thickness=1):
+        # Create pen for drawing
+        color = rgb_to_rgba(color)
+        self._pen = aggdraw.Pen(color[:3], thickness, color[3])
+        # Create reusable drawing surface
+        self.surf = aggdraw.Draw("RGBA", P.screen_x_y, (0, 0, 0, 0))
+        self.surf.setantialias(True)
+        self._raw = None # surface bytes, empty until rendered
+
+    def update(self, points):
+        # Adds the line between the last two points to the surface
+        if len(points) >= 2:
+            p1 = "M{0},{1}".format(*points[-2][:2])
+            p2 = "L{0},{1}".format(*points[-1][:2])
+            self.surf.symbol((0, 0), aggdraw.Symbol(p1 + p2), self._pen)
+
+    def render(self):
+        # Get the raw RGBA bytes from the drawing surface
+        self._raw = self.surf.tobytes()
+        # Cast the raw bytes directly to a blittable numpy array
+        arr = np.frombuffer(self._raw, dtype=np.uint8)
+        return arr.reshape(self.surf.size[1], self.surf.size[0], 4)

--- a/ExpAssets/Resources/code/responselisteners.py
+++ b/ExpAssets/Resources/code/responselisteners.py
@@ -93,6 +93,7 @@ class DrawingListener(BaseResponseListener):
             response been made, otherwise None.
 
         """
+        # NOTE: Could be improved further by setting a minimum max dist from origin?
         loc = get_touch_coords()
         timestamp = self._timestamp()
 

--- a/ExpAssets/Resources/code/responselisteners.py
+++ b/ExpAssets/Resources/code/responselisteners.py
@@ -1,0 +1,155 @@
+import aggdraw
+import klibs.KLParams as P
+from klibs.KLTime import precise_time
+from klibs.KLBoundary import Boundary
+from klibs.KLUserInterface import mouse_pos
+from klibs.KLResponseListeners import BaseResponseListener
+from klibs.KLGraphics.utils import rgb_to_rgba, aggdraw_to_array
+
+
+class DrawingListener(BaseResponseListener):
+    """A custom class for collecting drawing responses.
+
+    Args:
+        min_duration (float, optional): The minimum duration (in seconds) of the
+            drawing, to prevent premature/accidental response ends. Defaults to
+            0.25 seconds.
+        timeout (float, optional): The maximum duration (in seconds) to wait for a
+            valid response. Defaults to None (no timeout).
+        loop_callback (callable, optional): An optional function or method to be
+            called every time the collection loop checks for new input.
+
+    """
+    def __init__(self, min_duration=0.25, timeout=None, loop_callback=None):
+        super(DrawingListener, self).__init__(timeout, loop_callback)
+        self.origin_boundary = None
+        self.min_duration = min_duration
+        # Runtime
+        self.points = []
+        self._origin_touched = None
+        self._drawing_start = None
+
+    def _timestamp(self):
+        # NOTE: precise_time seems to be more consistent than time.perf_counter here
+        # for some reason even though it should theoretically be identical.
+        return precise_time()
+
+    def set_origin(self, origin):
+        """Sets the boundary to use for the origin point of the drawing.
+
+        Args:
+            origin (:obj:`~klibs.KLBoundary.Boundary`): The boundary to use for
+                the start/end point of the drawing.
+
+        """
+        if not isinstance(origin, Boundary):
+            e = "'origin' must be a valid Boundary object."
+            raise TypeError(e)
+        self.origin_boundary = origin
+
+    def collect(self):
+        """Collects a drawing response from the participant.
+
+        drawing: A list of x/y coordinates (in pixels) and their corresponding
+            timestamps (in seconds) relative to drawing start representing the
+            trajectory and timecourse of the drawing. Each sample is formatted
+            as `(x, y, timestamp)`.
+        rt: Reaction time, defined as the interval between response collection
+            start and the participant touching the origin.
+        it: Initiation time, defined as the interval between the participant
+            touching the origin and the start of the actual drawing.
+        mt: Movement time, defined as the interval between the start of the
+            drawing and the end of the drawing (return to origin).
+
+        Returns:
+            tuple: A ``(drawing, rt, it, mt)`` tuple containing the drawing trajectory
+            and its reaction time, initiation time, and movement time.
+
+        """
+        return super(DrawingListener, self).collect()
+
+    def init(self):
+        """Initializes the listener for response collection.
+
+        """
+        if not self.origin_boundary:
+            e = "Origin point must be set before collecting a drawing response."
+            raise RuntimeError(e)
+        self._loop_start = self._timestamp()
+
+    def listen(self, q):
+        """Updates the state of the drawing based on cursor movements.
+
+        Args:
+            q (list): A list of input events. Unused for this listener.
+
+        Returns:
+            tuple or None: A ``(drawing, rt, it, mt)`` tuple if a complete draw
+            response been made, otherwise None.
+
+        """
+        loc = mouse_pos()
+        timestamp = self._timestamp()
+
+        # If response not initiated, check if cursor is within origin and start if so
+        if not self.started:
+            if loc in self.origin_boundary:
+                self._origin_touched = timestamp
+
+        # If within origin after drawing start, end drawing if min duration has elapsed
+        elif self._drawing_start and loc in self.origin_boundary:
+            last_timestamp = self.points[-1][-1]
+            if last_timestamp > self.min_duration and len(self.points) >= 2:
+                rt = round(self._origin_touched - self._loop_start, 4)
+                it = round(self._drawing_start - self._origin_touched, 4)
+                mt = round(self.points[-1][2], 4)
+                return (self.points, rt, it, mt)
+
+        # Once response is initiated and cursor leaves origin, start recording drawing
+        if self.started and not loc in self.origin_boundary:
+            if not self._drawing_start:
+                self._drawing_start = timestamp
+                p = (loc[0], loc[1], 0.0)
+            else:
+                p = (loc[0], loc[1], round(timestamp - self._drawing_start, 7))
+            self.points.append(p)
+
+        return None
+
+    def cleanup(self):
+        """Resets the listener state after a response has been collected.
+
+        """
+        self.points = []
+        self._loop_start = None
+        self._origin_touched = None
+        self._drawing_start = None
+
+    @property
+    def started(self):
+        """bool: True if the tracing has been initiated, otherwise False.
+
+        """
+        return self._origin_touched != None
+
+    @property
+    def draw_time(self):
+        """float: The time elapsed since the start of the actual drawing.
+
+        """
+        if not self._drawing_start:
+            return 0.0
+        return self._timestamp() - self._drawing_start
+
+
+def render_tracing(points, color, thickness=1):
+    surf = aggdraw.Draw("RGBA", P.screen_x_y, (0, 0, 0, 0))
+    surf.setantialias(True)
+    color = rgb_to_rgba(color)
+    if len(points) >= 2:
+        m_str = "M{0},{1}".format(points[0][0], points[0][1])
+        for p in points[1:]:
+            m_str += "L{0},{1}".format(p[0], p[1])
+        s = aggdraw.Symbol(m_str)
+        surf.symbol((0, 0), s, aggdraw.Pen(color[:3], thickness, color[3]))
+    return aggdraw_to_array(surf)

--- a/ExpAssets/Resources/code/utils.py
+++ b/ExpAssets/Resources/code/utils.py
@@ -1,5 +1,8 @@
 import socket
+import ctypes
+
 import sdl2
+import klibs.KLParams as P
 
 
 def touchscreen_detected():
@@ -13,6 +16,17 @@ def touchscreen_detected():
 		if devtype == sdl2.SDL_TOUCH_DEVICE_DIRECT:
 			return True
 	return False
+
+
+def get_touch_coords():
+	# Returns the x/y coordinates of the mouse cursor (if finger on screen)
+    sdl2.SDL_PumpEvents()
+    cx, cy = ctypes.c_int(0), ctypes.c_int(0)
+    b_state = sdl2.SDL_GetMouseState(ctypes.byref(cx), ctypes.byref(cy))
+    x = int(cx.value * P.screen_scale_x)
+    y = int(cy.value * P.screen_scale_y)
+    lifted = (b_state & sdl2.SDL_BUTTON(sdl2.SDL_BUTTON_LEFT)) == 0
+    return None if lifted else (x, y)
 
 
 def get_hostname():

--- a/experiment.py
+++ b/experiment.py
@@ -14,7 +14,7 @@ from klibs.KLConstants import STROKE_OUTER
 from klibs.KLBoundary import BoundaryInspector, RectangleBoundary, CircleBoundary
 from klibs.KLTime import CountDown, precise_time
 from klibs.KLUserInterface import any_key, ui_request, show_cursor, hide_cursor, mouse_clicked
-from klibs.KLUtilities import pump, flush, scale, now, mouse_pos, utf8
+from klibs.KLUtilities import pump, flush, scale, now, utf8
 from klibs.KLUtilities import colored_stdout as cso
 from klibs.KLGraphics import blit, fill, flip
 from klibs.KLGraphics.KLDraw import Ellipse, Rectangle
@@ -23,7 +23,7 @@ from klibs.KLCommunication import user_queries, message, query
 
 from TraceLabSession import TraceLabSession
 from TraceLabFigure import TraceLabFigure, save_figure, save_template
-from utils import touchscreen_detected, get_hostname
+from utils import touchscreen_detected, get_hostname, get_touch_coords
 from ButtonBar import ButtonBar
 from responselisteners import DrawingListener, DrawSurface
 from instructions import play_tutorial
@@ -483,9 +483,8 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 		start = time.perf_counter()
 		at_origin = False
 		while not at_origin:
-			x, y, button = mouse_pos(return_button_state=True)
-			left_button_down = button == 1
-			if self.within_boundary('origin', (x, y)) and left_button_down:
+			loc = get_touch_coords()
+			if loc and self.within_boundary('origin', loc):
 				at_origin = True
 				self.rt = time.perf_counter() - start
 			ui_request()
@@ -494,9 +493,8 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 		flip()
 
 		while at_origin:
-			x, y, button = mouse_pos(return_button_state=True)
-			left_button_down = button == 1
-			if not (self.within_boundary('origin', (x, y)) and left_button_down):
+			loc = get_touch_coords()
+			if not (loc and self.within_boundary('origin', loc)):
 				at_origin = False
 		self.mt = time.perf_counter() - (self.rt + start)
 

--- a/experiment.py
+++ b/experiment.py
@@ -10,8 +10,8 @@ from random import choice
 
 import klibs
 from klibs import P
-from klibs.KLConstants import RECT_BOUNDARY, CIRCLE_BOUNDARY, STROKE_OUTER, QUERY_UPD
-from klibs.KLBoundary import BoundaryInspector, RectangleBoundary
+from klibs.KLConstants import STROKE_OUTER
+from klibs.KLBoundary import BoundaryInspector, RectangleBoundary, CircleBoundary
 from klibs.KLTime import CountDown, precise_time
 from klibs.KLUserInterface import any_key, ui_request, show_cursor, hide_cursor, mouse_clicked
 from klibs.KLUtilities import pump, flush, scale, now, mouse_pos, utf8
@@ -20,12 +20,12 @@ from klibs.KLGraphics import blit, fill, flip
 from klibs.KLGraphics.KLDraw import Ellipse, Rectangle
 from klibs.KLText import add_text_style
 from klibs.KLCommunication import user_queries, message, query
-from klibs.KLResponseCollectors import DrawResponse
 
 from TraceLabSession import TraceLabSession
 from TraceLabFigure import TraceLabFigure, save_figure, save_template
 from utils import touchscreen_detected, get_hostname
 from ButtonBar import ButtonBar
+from responselisteners import DrawingListener, render_tracing
 from instructions import play_tutorial
 
 
@@ -33,9 +33,7 @@ WHITE = (255, 255, 255, 255)
 BLACK = (0, 0, 0, 255)
 RED = (255, 0, 0, 255)
 GREEN = (0, 255, 0, 255)
-BOT_L = 0
-TOP_L = 1
-TOP_R = 2
+TRACE_COLOUR = (255, 80, 125, 255)
 
 # condition codes; jon hates retyping strings
 PHYS = "physical"
@@ -120,14 +118,8 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 		self.animate_time = P.practice_animation_time
 
 		self.__practicing__ = True
-		self.setup_response_collector()
 		self.trial_prep()
-		self.evm.start()
-		try:
-			self.trial()
-		except:
-			pass
-		self.evm.reset()
+		self.trial()
 		self.trial_clean_up()
 		self.__practicing__ = False
 
@@ -195,6 +187,9 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 			message_txt = P.control_q
 		)
 
+		# Initialize the drawing response listener
+		self.draw_listener = DrawingListener(loop_callback=self.display_refresh)
+
 		# Initialize 'next trial' button
 		button_x = 250 if self.handedness == LEFT_HANDED else P.screen_x - 250
 		button_y = P.screen_y - 100
@@ -226,10 +221,8 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 		# Determine whether cursor should be shown or hidden
 		touchscreen = touchscreen_detected()
 		if P.force_show_cursor or (P.development_mode and not touchscreen):
-			self.show_cursor = True
 			show_cursor()
 		else:
-			self.show_cursor = False
 			hide_cursor()
 
 		# Import all pre-generated figures needed for the current session
@@ -284,23 +277,6 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 		any_key()
 
 
-	def setup_response_collector(self):
-
-		self.rc.uses(DrawResponse)
-		self.rc.terminate_after = [120, klibs.TK_S] # Wait really long before timeout
-		self.rc.draw_listener.start_boundary = 'start'
-		self.rc.draw_listener.stop_boundary = 'stop'
-		self.rc.draw_listener.show_active_cursor = self.show_cursor
-		self.rc.draw_listener.show_inactive_cursor = self.show_cursor
-		self.rc.draw_listener.origin = self.origin_pos
-		self.rc.draw_listener.interrupts = True
-		self.rc.draw_listener.min_samples = 5
-		self.rc.display_callback = self.display_refresh
-
-		if self.feedback_type in (FB_DRAW, FB_ALL):
-			self.rc.draw_listener.render_real_time = True
-
-
 	def trial_prep(self):
 
 		# If reloading incomplete block, update trial number accordingly
@@ -329,14 +305,9 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 
 		# Initialize origin position and origin boundaries based on the loaded figure
 		self.origin_pos = list(self.figure.points[0])
-		if P.flip_x:
-			self.origin_pos[0] = P.screen_x - self.origin_pos[0]
-		self.origin_boundary = [self.origin_pos, P.origin_size // 2]
-		self.add_boundary("origin", self.origin_boundary, CIRCLE_BOUNDARY)
-		self.rc.draw_listener.add_boundaries([
-			('start', self.origin_boundary, CIRCLE_BOUNDARY),
-			('stop', self.origin_boundary, CIRCLE_BOUNDARY)
-		])
+		origin_bounds = CircleBoundary('origin', self.origin_pos, P.origin_size // 2)
+		self.add_boundary(origin_bounds)
+		self.draw_listener.set_origin(origin_bounds)
 
 		# Let participant self-initiate next trial
 		self.start_trial_button()
@@ -406,7 +377,6 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 		if not self.__practicing__:
 			outpath = os.path.join(self.fig_dir, self.file_name + ".zip")
 			save_figure(outpath, self.figure, self.a_frames, self.drawing)
-		self.rc.draw_listener.reset()
 
 
 	def clean_up(self):
@@ -419,13 +389,9 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 			learned_fig_num = 1
 			if query(user_queries.experimental[3]) == "y":
 				self.origin_pos = (P.screen_c[0], int(P.screen_y * 0.8))
-				self.origin_boundary = [self.origin_pos, P.origin_size // 2]
+				origin = CircleBoundary('origin', self.origin_pos, P.origin_size // 2)
+				self.draw_listener.set_origin(origin)
 				while True:
-					self.setup_response_collector()
-					self.rc.draw_listener.add_boundaries([
-						('start', self.origin_boundary, CIRCLE_BOUNDARY),
-						('stop', self.origin_boundary, CIRCLE_BOUNDARY)
-					])
 					self.start_trial_button()
 					self.capture_learned_figure(learned_fig_num)
 					if query(user_queries.experimental[4]) == "y":
@@ -496,14 +462,11 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 	def display_refresh(self):
 
 		fill()
-		origin = self.origin_active if self.rc.draw_listener.active else self.origin_inactive
+		origin = self.origin_active if self.draw_listener.started else self.origin_inactive
 		blit(origin, 5, self.origin_pos, flip_x=P.flip_x)
 		if P.dm_render_progress or self.feedback_type in (FB_ALL, FB_DRAW):
-			try:
-				drawing = self.rc.draw_listener.render_progress()
-				blit(drawing, 5, P.screen_c, flip_x=P.flip_x)
-			except TypeError:
-				pass
+			drawing = render_tracing(self.draw_listener.points, TRACE_COLOUR, 1)
+			blit(drawing, 7, (0, 0))
 		flip()
 
 
@@ -536,11 +499,9 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 
 	def physical_trial(self):
 
-		self.rc.collect()
-		self.rt = self.rc.draw_listener.start_time
-		self.drawing = self.rc.draw_listener.responses[0][0]
-		self.it = self.rc.draw_listener.first_sample_time - self.rt
-		self.mt = self.rc.draw_listener.responses[0][1]
+		self.display_refresh()
+		resp = self.draw_listener.collect()
+		self.drawing, self.rt, self.it, self.mt = resp
 
 
 	def control_trial(self):
@@ -662,13 +623,11 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 
 	def capture_learned_figure(self, fig_number):
 
-		self.evm.start()
 		outfile = "p{0}_learned_figure_{1}.zip".format(self.filename_id, fig_number)
 		outpath = os.path.join(self.fig_dir, outfile)
-		self.rc.draw_listener.reset()
-		self.rc.collect()
-		save_figure(outpath, tracing=self.rc.draw_listener.responses[0][0])
-		self.evm.reset()
+		self.display_refresh()
+		learned = self.draw_listener.collect()[0]
+		save_figure(outpath, tracing=learned)
 
 
 	def practice_menu(self):

--- a/experiment.py
+++ b/experiment.py
@@ -493,8 +493,9 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 		flip()
 
 		while at_origin:
+			# Wait until finger lifted to end response
 			loc = get_touch_coords()
-			if not (loc and self.within_boundary('origin', loc)):
+			if not loc:
 				at_origin = False
 		self.mt = time.perf_counter() - (self.rt + start)
 

--- a/experiment.py
+++ b/experiment.py
@@ -25,7 +25,7 @@ from TraceLabSession import TraceLabSession
 from TraceLabFigure import TraceLabFigure, save_figure, save_template
 from utils import touchscreen_detected, get_hostname
 from ButtonBar import ButtonBar
-from responselisteners import DrawingListener, render_tracing
+from responselisteners import DrawingListener, DrawSurface
 from instructions import play_tutorial
 
 
@@ -294,6 +294,7 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 		self.figure = None
 		self.drawing = None
 		self.a_frames = [] # figure animation frames
+		self.live_feedback = None
 
 		# Either load a pre-generated figure or generate a new one, depending on trial
 		if self.figure_name == "random":
@@ -465,7 +466,10 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 		origin = self.origin_active if self.draw_listener.started else self.origin_inactive
 		blit(origin, 5, self.origin_pos, flip_x=P.flip_x)
 		if P.dm_render_progress or self.feedback_type in (FB_ALL, FB_DRAW):
-			drawing = render_tracing(self.draw_listener.points, TRACE_COLOUR, 1)
+			if not self.live_feedback:
+				self.live_feedback = DrawSurface(P.screen_x_y, TRACE_COLOUR, 1)
+			self.live_feedback.update(self.draw_listener.points)
+			drawing = self.live_feedback.render()
 			blit(drawing, 7, (0, 0))
 		flip()
 
@@ -625,6 +629,7 @@ class TraceLab(klibs.Experiment, BoundaryInspector):
 
 		outfile = "p{0}_learned_figure_{1}.zip".format(self.filename_id, fig_number)
 		outpath = os.path.join(self.fig_dir, outfile)
+		self.live_feedback = None
 		self.display_refresh()
 		learned = self.draw_listener.collect()[0]
 		save_figure(outpath, tracing=learned)


### PR DESCRIPTION
This PR adds a new DrawListener class based on the KLibs ResponseListener API, replacing the use of the deprecated ResponseCollector API, along with a number of tweaks and improvements. This allows the draw response collection code to be contained within TraceLab itself and thus easier to tweak and less likely to break with future KLibs updates.

### List of Changes:

- Instead of requiring a minimum number of samples to allow the trial to end (previously 5), the new listener instead uses a minimum duration (0.25 seconds after drawing start) to reduce accidental trial ends.
- Live feedback rendering for PP-VV/PP-VR trials has been rewritten and heavily optimized, fixing performance issues with dropped frames due to slow rendering.
- Drawing samples are now only recorded if the participant is actually touching the screen. Previously the task would just record duplicate samples if the screen lost track of the finger until the finger returned.
- Draw responses now only end if the participant was already registered as touching the screen prior to entering origin. This guarantees that the final timestamp of the drawing reflects when the drawing actually ended but also allows participants to retry a drawing after a false start or a failed recording (finger not registered during drawing). Should hopefully reduce the number of trials with no discernible shape.
- Imagery trials have been modified to only end once the participant lifts their finger from the screen (would previously end if their finger was lifted *or* was outside origin, which could sometimes cause accidental trial ends)

The basic code has already been tested in https://github.com/LBRF-Projects/Feedback_Gaughan2025 and refined based on the filtered trials in that dataset (specifically the slide-to-origin requirement).